### PR TITLE
Add chess game to arcade cabinet

### DIFF
--- a/arcade/index.html
+++ b/arcade/index.html
@@ -14,6 +14,7 @@
             <ul id="game-list">
                 <li><a href="../snake.html">Snake Evolution</a></li>
                 <li><a href="../sorting.html">Sorting Visualizer</a></li>
+                <li><a href="../chess.html">Chess</a></li>
             </ul>
         </div>
         <div class="controls">

--- a/chess.html
+++ b/chess.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Chess Game</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/chessboardjs@0.0.1/www/css/chessboard.css">
+    <link rel="stylesheet" href="chess/style.css">
+</head>
+<body>
+    <a href="index.html" class="back-link">Back to Main Site</a>
+    <div id="board"></div>
+    <script src="https://cdn.jsdelivr.net/npm/chessboardjs@0.0.1/www/js/jquery-1.10.1.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chessboardjs@0.0.1/www/js/chess.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chessboardjs@0.0.1/www/js/chessboard.js"></script>
+    <script src="chess/script.js"></script>
+</body>
+</html>

--- a/chess/script.js
+++ b/chess/script.js
@@ -1,0 +1,41 @@
+let board = null;
+let game = new Chess();
+
+function onDragStart(source, piece) {
+  if (game.game_over()) return false;
+  if (piece.search(/^b/) !== -1) return false;
+}
+
+function makeRandomMove() {
+  const possibleMoves = game.moves();
+  if (possibleMoves.length === 0) return;
+  const randomIdx = Math.floor(Math.random() * possibleMoves.length);
+  game.move(possibleMoves[randomIdx]);
+  board.position(game.fen());
+}
+
+function onDrop(source, target) {
+  const move = game.move({
+    from: source,
+    to: target,
+    promotion: 'q'
+  });
+  if (move === null) return 'snapback';
+  window.setTimeout(makeRandomMove, 250);
+}
+
+function onSnapEnd() {
+  board.position(game.fen());
+}
+
+function init() {
+  board = Chessboard('board', {
+    draggable: true,
+    position: 'start',
+    onDragStart: onDragStart,
+    onDrop: onDrop,
+    onSnapEnd: onSnapEnd
+  });
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/chess/style.css
+++ b/chess/style.css
@@ -1,0 +1,21 @@
+body {
+    font-family: 'Quicksand', sans-serif;
+    background-color: #222;
+    color: #eee;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin: 0;
+    padding: 20px;
+}
+
+.back-link {
+    margin-bottom: 20px;
+    color: #0aa;
+    text-decoration: none;
+}
+
+#board {
+    width: 400px;
+    margin-bottom: 20px;
+}


### PR DESCRIPTION
## Summary
- add Chess page with simple gameplay using chessboard.js
- include board script and style
- expose Chess game on arcade cabinet menu

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68447968dd6c83329a5b6108d7fce6e5