### PR TITLE
Add mobile detection and controls for Breakout

### DIFF
--- a/arcade/index.html
+++ b/arcade/index.html
@@ -11,6 +11,7 @@
     <div class="cabinet">
         <div class="screen">
             <h1>Arcade Games</h1>
+            <p id="platform-message"></p>
             <ul id="game-list">
                 <li><a href="../snake.html">Snake Evolution</a></li>
                 <li><a href="../hangman.html">Hangman</a></li>

--- a/arcade/script.js
+++ b/arcade/script.js
@@ -1,2 +1,11 @@
-// placeholder for future interactive features
-console.log('Arcade loaded');
+function isMobile() {
+    return /Mobi|Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+    const msgEl = document.getElementById('platform-message');
+    if (msgEl) {
+        msgEl.textContent = isMobile() ? 'Running on mobile device' : 'Running on desktop';
+    }
+    console.log('Arcade loaded');
+});

--- a/breakout.html
+++ b/breakout.html
@@ -9,6 +9,10 @@
 <body>
     <a href="arcade/index.html" style="color:#0aa;text-decoration:none;">Back to Main Site</a>
     <canvas id="breakoutCanvas" width="480" height="320"></canvas>
+    <div id="mobile-controls" style="display:none;">
+        <button id="leftBtn">&#9664;</button>
+        <button id="rightBtn">&#9654;</button>
+    </div>
     <script type="module" src="breakout/game.js"></script>
 </body>
 </html>

--- a/breakout/game.js
+++ b/breakout/game.js
@@ -1,6 +1,16 @@
 const canvas = document.getElementById('breakoutCanvas');
 const ctx = canvas.getContext('2d');
 
+const isMobile = /Mobi|Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+const mobileControls = document.getElementById('mobile-controls');
+if (isMobile && mobileControls) {
+  mobileControls.style.display = 'flex';
+}
+
+if (isMobile) {
+  document.body.addEventListener('touchmove', (e) => e.preventDefault(), { passive: false });
+}
+
 const paddleHeight = 10;
 const paddleWidth = 75;
 let paddleX = (canvas.width - paddleWidth) / 2;
@@ -10,6 +20,29 @@ let leftPressed = false;
 
 document.addEventListener('keydown', keyDownHandler, false);
 document.addEventListener('keyup', keyUpHandler, false);
+
+if (isMobile) {
+  const leftBtn = document.getElementById('leftBtn');
+  const rightBtn = document.getElementById('rightBtn');
+  if (leftBtn && rightBtn) {
+    const pressLeft = () => { leftPressed = true; };
+    const releaseLeft = () => { leftPressed = false; };
+    const pressRight = () => { rightPressed = true; };
+    const releaseRight = () => { rightPressed = false; };
+    leftBtn.addEventListener('touchstart', pressLeft);
+    leftBtn.addEventListener('touchend', releaseLeft);
+    rightBtn.addEventListener('touchstart', pressRight);
+    rightBtn.addEventListener('touchend', releaseRight);
+  }
+
+  canvas.addEventListener('touchmove', (e) => {
+    const rect = canvas.getBoundingClientRect();
+    const touch = e.touches[0];
+    const relativeX = touch.clientX - rect.left;
+    paddleX = Math.min(Math.max(relativeX - paddleWidth / 2, 0), canvas.width - paddleWidth);
+    e.preventDefault();
+  }, { passive: false });
+}
 
 function keyDownHandler(e) {
   if (e.key === 'Right' || e.key === 'ArrowRight') {

--- a/breakout/style.css
+++ b/breakout/style.css
@@ -5,6 +5,8 @@ body {
     font-family: 'Courier New', monospace;
     margin: 0;
     padding: 20px;
+    height: 100vh;
+    overflow: hidden;
 }
 
 canvas {
@@ -12,4 +14,16 @@ canvas {
     display: block;
     margin: 20px auto;
     border: 4px solid #444;
+}
+
+#mobile-controls {
+    display: flex;
+    justify-content: center;
+    gap: 20px;
+    margin-top: 10px;
+}
+
+#mobile-controls button {
+    font-size: 24px;
+    padding: 10px 20px;
 }


### PR DESCRIPTION
## Summary
- show platform info in arcade index
- implement detection of mobile devices
- add on-screen controls and touch move support in Breakout
- disable scrolling on Breakout page for mobile

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684490a970288332b4ba192afe028706