### PR TITLE
Fix mobile breakout layout

### DIFF
--- a/breakout/game.js
+++ b/breakout/game.js
@@ -1,6 +1,9 @@
 const canvas = document.getElementById('breakoutCanvas');
 const ctx = canvas.getContext('2d');
 
+// Prevent context menu on long press
+document.addEventListener('contextmenu', (e) => e.preventDefault());
+
 const isMobile = /Mobi|Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
 const mobileControls = document.getElementById('mobile-controls');
 if (isMobile && mobileControls) {

--- a/breakout/style.css
+++ b/breakout/style.css
@@ -4,16 +4,28 @@ body {
     color: white;
     font-family: 'Courier New', monospace;
     margin: 0;
-    padding: 20px;
     height: 100vh;
     overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    user-select: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    -webkit-touch-callout: none;
 }
 
 canvas {
     background: #000;
     display: block;
-    margin: 20px auto;
+    margin: 0 auto;
     border: 4px solid #444;
+    box-sizing: border-box;
+    width: 100vw;
+    height: 100vh;
+    object-fit: contain;
+    touch-action: none;
 }
 
 #mobile-controls {
@@ -21,9 +33,15 @@ canvas {
     justify-content: center;
     gap: 20px;
     margin-top: 10px;
+    user-select: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
 }
 
 #mobile-controls button {
     font-size: 24px;
     padding: 10px 20px;
+    user-select: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
 }


### PR DESCRIPTION
## Summary
- keep users from selecting the on-screen controls
- scale Breakout canvas to the full viewport
- prevent the mobile copy/paste menu from appearing

## Testing
- `npm test` *(fails: package.json not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6844949a6d5c8332ba3ac7be6a117b82