### PR TITLE
Fix memory match scrolling on mobile

### DIFF
--- a/memory-match/style.css
+++ b/memory-match/style.css
@@ -6,7 +6,9 @@ body {
     flex-direction: column;
     align-items: center;
     padding-top: 20px;
-    min-height: 100vh;
+    height: 100vh;
+    box-sizing: border-box;
+    overflow: hidden;
     margin: 0;
 }
 


### PR DESCRIPTION
## Summary
- prevent page scrolling on the Memory Match page so it fits in the viewport on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844957af37883329c248ee4f9f38884