### PR TITLE
Enhance 2048 mobile controls

### DIFF
--- a/2048/script.js
+++ b/2048/script.js
@@ -1,4 +1,5 @@
 const size = 4;
+const isMobile = /Mobi|Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
 let board = [];
 let score = 0;
 
@@ -11,6 +12,9 @@ function init() {
     document.addEventListener('keydown', handleKey);
     document.addEventListener('touchstart', handleTouchStart, { passive: false });
     document.addEventListener('touchend', handleTouchEnd, { passive: false });
+    if (isMobile) {
+        document.body.addEventListener('touchmove', (e) => e.preventDefault(), { passive: false });
+    }
 }
 
 function handleKey(e) {
@@ -47,6 +51,7 @@ function handleTouchStart(e) {
         touchStartX = e.touches[0].clientX;
         touchStartY = e.touches[0].clientY;
     }
+    if (e.preventDefault) e.preventDefault();
 }
 
 function handleTouchEnd(e) {

--- a/2048/style.css
+++ b/2048/style.css
@@ -7,6 +7,7 @@ body {
     justify-content: center;
     min-height: 100vh;
     margin: 0;
+    overflow: hidden;
 }
 
 .back-link {


### PR DESCRIPTION
## Summary
- prevent page scrolling while playing 2048
- detect mobile devices and block touchmove events
- prevent default touch behaviour when swiping

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684495da8eb083329ed316c851b28453