### PR TITLE
Add mobile controls for Tetris

### DIFF
--- a/tetris/game.js
+++ b/tetris/game.js
@@ -1,6 +1,9 @@
 const canvas = document.getElementById('tetris');
 const context = canvas.getContext('2d');
 
+// Mobile detection used throughout the project
+const isMobile = /Mobi|Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+
 const grid = 20;
 const cols = 10;
 const rows = 20;
@@ -233,6 +236,49 @@ document.addEventListener('keydown', event => {
         playerRotate(1);
     }
 });
+
+// Touch controls for mobile devices
+let touchStartX = null;
+let touchStartY = null;
+
+function handleTouchStart(e) {
+    if (e.touches.length === 1) {
+        touchStartX = e.touches[0].clientX;
+        touchStartY = e.touches[0].clientY;
+    }
+    if (e.preventDefault) e.preventDefault();
+}
+
+function handleTouchEnd(e) {
+    if (touchStartX === null || touchStartY === null) return;
+    const dx = e.changedTouches[0].clientX - touchStartX;
+    const dy = e.changedTouches[0].clientY - touchStartY;
+    const absX = Math.abs(dx);
+    const absY = Math.abs(dy);
+    if (Math.max(absX, absY) > 30) {
+        if (absX > absY) {
+            if (dx > 0) {
+                playerMove(1);
+            } else {
+                playerMove(-1);
+            }
+        } else {
+            if (dy > 0) {
+                playerDrop();
+            } else {
+                playerRotate(1);
+            }
+        }
+    }
+    touchStartX = touchStartY = null;
+    if (e.preventDefault) e.preventDefault();
+}
+
+if (isMobile) {
+    document.body.addEventListener('touchmove', e => e.preventDefault(), { passive: false });
+    document.addEventListener('touchstart', handleTouchStart, { passive: false });
+    document.addEventListener('touchend', handleTouchEnd, { passive: false });
+}
 
 const arena = createMatrix(cols, rows);
 const player = {

--- a/tetris/style.css
+++ b/tetris/style.css
@@ -5,6 +5,7 @@ body {
     justify-content: center;
     height: 100vh;
     margin: 0;
+    overflow: hidden;
     background: #000;
     color: #fff;
     font-family: 'Courier New', monospace;


### PR DESCRIPTION
## Summary
- detect mobile devices in Tetris
- disable scrolling on mobile
- map swipe gestures to game actions
- prevent scrolling via CSS

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844d20c5f488332a76d20868369a1f8